### PR TITLE
Remove short-circuit evaluation in --ref option

### DIFF
--- a/git-memo
+++ b/git-memo
@@ -111,7 +111,8 @@ fetch() {
 
 main() {
   if [ "$1" = "--ref" ]; then
-    git notes "$@" && exit $? # works as original git-notes
+    git notes "$@" # works as original git-notes
+    exit $?
   fi
 
   if [ "__-h" == "__$1" ]; then


### PR DESCRIPTION
I'm sorry if this change is against your will.
